### PR TITLE
Added timestamp to metrics in ttl cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,21 +165,21 @@ A JSON response will be sent in the following form:
       "ValueMetrics":{
          "MetricName":{
            "value": integer_value,
-           "timestamp": interger_unix_nanosecond_timestamp
+           "timestamp": integer_unix_nanosecond_timestamp
          },
          "MetricName":{
            "value": integer_value,
-           "timestamp": interger_unix_nanosecond_timestamp
+           "timestamp": integer_unix_nanosecond_timestamp
          }
       },
       "CounterMetrics":{
          "MetricName":{
            "value": integer_value,
-           "timestamp": interger_unix_nanosecond_timestamp
+           "timestamp": integer_unix_nanosecond_timestamp
          },
          "MetricName":{
            "value": integer_value,
-           "timestamp": interger_unix_nanosecond_timestamp
+           "timestamp": integer_unix_nanosecond_timestamp
          }
       }
    }

--- a/README.md
+++ b/README.md
@@ -163,12 +163,24 @@ A JSON response will be sent in the following form:
       "Index":"0",
       "IP":"X.X.X.X",
       "ValueMetrics":{
-         "MetricName":integer_value,
-         "MetricName":integer_value
+         "MetricName":{
+           "value": integer_value,
+           "timestamp": interger_unix_nanosecond_timestamp
+         },
+         "MetricName":{
+           "value": integer_value,
+           "timestamp": interger_unix_nanosecond_timestamp
+         }
       },
       "CounterMetrics":{
-         "MetricName":integer_value,
-         "MetricName":integer_value
+         "MetricName":{
+           "value": integer_value,
+           "timestamp": interger_unix_nanosecond_timestamp
+         },
+         "MetricName":{
+           "value": integer_value,
+           "timestamp": interger_unix_nanosecond_timestamp
+         }
       }
    }
 ]

--- a/ttlcache/metric.go
+++ b/ttlcache/metric.go
@@ -8,8 +8,9 @@ import (
 //Metric represents a single dropsonde metric
 type Metric struct {
 	sync.RWMutex
-	data    float64
-	expires *time.Time
+	data      float64
+	timestamp int64
+	expires   *time.Time
 }
 
 func (m *Metric) getData() float64 {
@@ -18,12 +19,19 @@ func (m *Metric) getData() float64 {
 	return m.data
 }
 
-func (m *Metric) update(newData float64, duration time.Duration) {
+func (m *Metric) getTimestamp() int64 {
+	m.RLock()
+	defer m.RUnlock()
+	return m.timestamp
+}
+
+func (m *Metric) update(newData float64, newTimestamp int64, duration time.Duration) {
 	m.Lock()
 	defer m.Unlock()
 	expiration := time.Now().Add(duration)
 	m.expires = &expiration
 	m.data = newData
+	m.timestamp = newTimestamp
 }
 
 func (m *Metric) expired() bool {

--- a/ttlcache/metric_test.go
+++ b/ttlcache/metric_test.go
@@ -30,11 +30,27 @@ func TestGetData(t *testing.T) {
 		t.Errorf("Expected %f got %f", data, metricData)
 	}
 }
+func TestGetTimestamp(t *testing.T) {
+	timestamp := time.Now().UnixNano()
+	metric := &Metric{timestamp: timestamp}
+
+	metricTimestamp := metric.getTimestamp()
+	if metricTimestamp != timestamp {
+		t.Errorf("Expected %d got %d", timestamp, metricTimestamp)
+	}
+}
 
 func TestUpdate(t *testing.T) {
 	metric := &Metric{}
-	metric.update(35, time.Second)
+	timestamp := time.Now().UnixNano()
+	data := float64(35)
+
+	metric.update(data, timestamp, time.Second)
 	if metric.expired() {
 		t.Error("Expected item to not be expired after update")
+	} else if metricData := metric.data; metricData != data {
+		t.Errorf("Expected data %f got %f", data, metricData)
+	} else if metricTime := metric.timestamp; metricTime != timestamp {
+		t.Errorf("Expected timestamp %d got %d", timestamp, metricTime)
 	}
 }

--- a/ttlcache/resource_test.go
+++ b/ttlcache/resource_test.go
@@ -97,6 +97,7 @@ func TestCleanup(t *testing.T) {
 
 func TestAddMetric(t *testing.T) {
 	origin, deployment, job, index, ip := "origin", "deployment", "job", "index", "ip"
+	timestamp := time.Now().UnixNano()
 	metricName, counterName := "metric", "counter"
 	value, delta, total := float64(24), uint64(24), uint64(24)
 	valueType, counterType := events.Envelope_ValueMetric, events.Envelope_CounterEvent
@@ -109,6 +110,7 @@ func TestAddMetric(t *testing.T) {
 		Job:        &job,
 		Index:      &index,
 		Ip:         &ip,
+		Timestamp:  &timestamp,
 		EventType:  &valueType,
 		ValueMetric: &events.ValueMetric{
 			Name:  &metricName,
@@ -122,6 +124,7 @@ func TestAddMetric(t *testing.T) {
 		Job:        &job,
 		Index:      &index,
 		Ip:         &ip,
+		Timestamp:  &timestamp,
 		EventType:  &counterType,
 		CounterEvent: &events.CounterEvent{
 			Name:  &counterName,
@@ -165,24 +168,24 @@ func TestConvertMap(t *testing.T) {
 	testCases := []struct {
 		testName string
 		input    map[string]*Metric
-		want     map[string]float64
+		want     map[string]metricJSON
 	}{
 		{
 			testName: "Blank Input",
 			input:    make(map[string]*Metric),
-			want:     make(map[string]float64),
+			want:     make(map[string]metricJSON),
 		},
 		{
 			testName: "Normal Input",
 			input: map[string]*Metric{
-				"one":   &Metric{data: 1},
-				"two":   &Metric{data: 2},
-				"three": &Metric{data: 3},
+				"one":   &Metric{data: 1, timestamp: int64(1257894000000000000)},
+				"two":   &Metric{data: 2, timestamp: int64(1257894000000000000)},
+				"three": &Metric{data: 3, timestamp: int64(1257894000000000000)},
 			},
-			want: map[string]float64{
-				"one":   1,
-				"two":   2,
-				"three": 3,
+			want: map[string]metricJSON{
+				"one":   metricJSON{Value: 1, Timestamp: int64(1257894000000000000)},
+				"two":   metricJSON{Value: 2, Timestamp: int64(1257894000000000000)},
+				"three": metricJSON{Value: 3, Timestamp: int64(1257894000000000000)},
 			},
 		},
 	}
@@ -206,13 +209,13 @@ func TestConvertMap(t *testing.T) {
 }
 
 func TestMarshalJSON(t *testing.T) {
-	want := `{"Deployment":"deployment","Job":"job","Index":"index","IP":"ip","ValueMetrics":{"one":1},"CounterMetrics":{"one":1}}`
+	want := `{"Deployment":"deployment","Job":"job","Index":"index","IP":"ip","ValueMetrics":{"one":{"value":1,"timestamp":1257894000000000000}},"CounterMetrics":{"one":{"value":1,"timestamp":1257894000000000000}}}`
 
 	resource := createTestResource()
 
-	resource.valueMetrics["one"] = &Metric{data: 1}
+	resource.valueMetrics["one"] = &Metric{data: 1, timestamp: int64(1257894000000000000)}
 
-	resource.counterMetrics["one"] = &Metric{data: 1}
+	resource.counterMetrics["one"] = &Metric{data: 1, timestamp: int64(1257894000000000000)}
 
 	messageBytes, err := resource.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
Added a timestamp to all metrics that is pulled directly from the dropsonde envelope.

New JSON will look like this for a single resource:

```
   {
      "Deployment":"deployment_name",
      "Job":"job_name",
      "Index":"0",
      "IP":"X.X.X.X",
      "ValueMetrics":{
         "MetricName":{
           "value": integer_value,
           "timestamp": integer_unix_nanosecond_timestamp
         },
         "MetricName":{
           "value": integer_value,
           "timestamp": integer_unix_nanosecond_timestamp
         }
      },
      "CounterMetrics":{
         "MetricName":{
           "value": integer_value,
           "timestamp": integer_unix_nanosecond_timestamp
         },
         "MetricName":{
           "value": integer_value,
           "timestamp": integer_unix_nanosecond_timestamp
         }
      }
   }
```