### PR TITLE
changed `/BlueMedora/` to `/BlueMedoraPublic/`

### DIFF
--- a/bluemedorafirehosenozzle/blue_medora_firehose_nozzle.go
+++ b/bluemedorafirehosenozzle/blue_medora_firehose_nozzle.go
@@ -6,11 +6,11 @@ package bluemedorafirehosenozzle
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/ttlcache"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/ttlcache"
 	"time"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/nozzleconfiguration"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/webserver"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/nozzleconfiguration"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/webserver"
 	"github.com/cloudfoundry-incubator/uaago"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/noaa/consumer"

--- a/main.go
+++ b/main.go
@@ -6,10 +6,10 @@ package main
 import (
 	"flag"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/bluemedorafirehosenozzle"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/logger"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/nozzleconfiguration"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/webserver"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/bluemedorafirehosenozzle"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/logger"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/nozzleconfiguration"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/webserver"
 )
 
 const (

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,4 +18,4 @@ applications:
     BM_WEBSERVER_USE_SSL: false
     BM_STDOUT_LOGGING: true
     BM_LOG_LEVEL: info
-    GOPACKAGENAME: github.com/BlueMedora/bluemedora-firehose-nozzle
+    GOPACKAGENAME: github.com/BlueMedoraPublic/bluemedora-firehose-nozzle

--- a/nozzleconfiguration/nozzle_configuration_test.go
+++ b/nozzleconfiguration/nozzle_configuration_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/logger"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/logger"
 )
 
 const (

--- a/webserver/web_server.go
+++ b/webserver/web_server.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/nozzleconfiguration"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/ttlcache"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/webtoken"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/nozzleconfiguration"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/ttlcache"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/webtoken"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/sonde-go/events"
 )

--- a/webserver/web_server_test.go
+++ b/webserver/web_server_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/logger"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/nozzleconfiguration"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/testhelpers"
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/ttlcache"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/logger"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/nozzleconfiguration"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/testhelpers"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/ttlcache"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 

--- a/webserver/web_server_utility.go
+++ b/webserver/web_server_utility.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/BlueMedora/bluemedora-firehose-nozzle/ttlcache"
+	"github.com/BlueMedoraPublic/bluemedora-firehose-nozzle/ttlcache"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/sonde-go/events"
 )


### PR DESCRIPTION
Go's package manager (dep) would find these dependencies and pull them
in instead of throwing an error that the dependencies wasn't defined in
`Gopkg.toml` this would result in a build that ran, but would be using
the current master branch of the repo.