### PR TITLE
Time series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-ompiled Object files, Static and Dynamic libs (Shared Objects)
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
 *.so

--- a/ttlcache/resource.go
+++ b/ttlcache/resource.go
@@ -71,8 +71,6 @@ func (r *Resource) AddMetric(envelope *events.Envelope, logger *gosteno.Logger) 
 	default:
 		logger.Warnf("Unknown event type %s", envelope.GetEventType())
 	}
-
-	logger.Debugf("After adding the metric: %s", metrics)
 }
 
 func (r *Resource) isEmpty() bool {

--- a/ttlcache/ttlcache_test.go
+++ b/ttlcache/ttlcache_test.go
@@ -116,7 +116,7 @@ func TestCacheCleanup(t *testing.T) {
 	}
 
 	resource := createTestResource()
-	resource.valueMetrics["test"] = []*Metric{&Metric{expires: &expiration}}
+	resource.valueMetrics["test"] = []*Metric{&Metric{expires: &expiration}, &Metric{expires: &expiration}}
 
 	cache.SetResource("origin", "key", resource)
 

--- a/ttlcache/ttlcache_test.go
+++ b/ttlcache/ttlcache_test.go
@@ -116,7 +116,7 @@ func TestCacheCleanup(t *testing.T) {
 	}
 
 	resource := createTestResource()
-	resource.valueMetrics["test"] = &Metric{expires: &expiration}
+	resource.valueMetrics["test"] = []*Metric{&Metric{expires: &expiration}}
 
 	cache.SetResource("origin", "key", resource)
 


### PR DESCRIPTION
Nozzle now captures/retains all data instead of just holding the latest.  The TTL cache now removes data that has expired but keeps the rest of the data points.

This was done to allow for better/more accurate aggregation of data in order to properly alert on conditions specified by PCF.